### PR TITLE
feat: add the ability to run keybinds when pressing enter instead of going to definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ Here are the defaults for the `setup()` method (that needs to be called) :
 
 ```lua
 require("nvim-mapper").setup({
-    no_map = false,                                        -- do not assign the default keymap (<leader>MM)
-    search_path = os.getenv("HOME") .. "/.config/nvim/lua" -- default config search path is ~/.config/nvim/lua
+    -- do not assign the default keymap (<leader>MM)
+    no_map = false,
+    -- where should ripgrep look for your keybinds definitions.
+    -- Default config search path is ~/.config/nvim/lua
+    search_path = os.getenv("HOME") .. "/.config/nvim/lua",
+    -- what should be done with the selected keybind when pressing enter.
+    -- Available actions:
+    --   * "definition" - Go to keybind definition (default)
+    --   * "execute" - Execute the keybind command
+    action_on_enter = "definition",
 })
 ```
 

--- a/lua/nvim-mapper.lua
+++ b/lua/nvim-mapper.lua
@@ -104,6 +104,13 @@ function M.setup(opts)
     else
         vim.g.mapper_search_path = os.getenv("HOME") .. "/.config/nvim/lua"
     end
+
+    -- Selected action
+    if opts.action_on_enter ~= nil then
+        vim.g.mapper_action_on_enter = opts.action_on_enter
+    else
+        vim.g.mapper_action_on_enter = "definition"
+    end
 end
 
 return M

--- a/lua/telescope/_extensions/mapper/main.lua
+++ b/lua/telescope/_extensions/mapper/main.lua
@@ -11,6 +11,28 @@ local M = {}
 
 -- This creates a picker with a list of all of the mappers
 M.mapper = function(opts)
+    -- If the enter key ('<CR>') should execute the selected
+    -- keybind then set a custom mapping
+    if vim.g.mapper_action_on_enter == "execute" then
+        opts = vim.tbl_extend("force", opts or {}, {
+            attach_mappings = function(prompt_bufnr)
+                local actions = require('telescope.actions')
+                local action_state = require('telescope.actions.state')
+                actions.select_default:replace(function()
+                    local keybind = action_state.get_selected_entry()
+                    -- Replace codes (e.g. '<CR>') with their internal representation
+                    local cmd_k = vim.api.nvim_replace_termcodes(keybind.keys, true, false, true)
+                    -- Send the keybinding to Neovim
+                    vim.api.nvim_feedkeys(cmd_k, "t", true)
+
+                    return actions.close(prompt_bufnr)
+                end)
+
+                return true
+            end,
+        })
+    end
+
     pickers.new(opts or {}, {
         prompt_title = 'Select a mapping',
         results_title = 'Mappings',


### PR DESCRIPTION
Hey, I was just looking how to execute the keybinds on enter instead of going to keybinds definition and I saw #7 but I thought it would be cool to have it in upstream.

Introduced a new option for the setup called `action_on_enter` (_and documented it, as it should be_) and if its value is `"execute"` then it will append a new `attach_mappings` function for the options passed in `mapper` function.

> All the credits of the `attach_mappings` function goes to [issadarkthing](https://github.com/issadarkthing), who shared it in the mentioned issue.