### PR TITLE
fix: use stdpath as it's OS aware, and respects XDG dir

### DIFF
--- a/lua/nvim-mapper.lua
+++ b/lua/nvim-mapper.lua
@@ -102,7 +102,7 @@ function M.setup(opts)
     if opts.search_path ~= nil then
         vim.g.mapper_search_path = opts.search_path
     else
-        vim.g.mapper_search_path = os.getenv("HOME") .. "/.config/nvim/lua"
+        vim.g.mapper_search_path = vim.fn.stdpath('config') .. "/lua"
     end
 end
 


### PR DESCRIPTION
See `:help stdpath()` and `:help standard-path`

**Benefits:**

1. Respects `$XDG_CONFIG_HOME` if set
2. if it isn't set, it is OS aware (uses the appropriate `AppData\Local` path on Windows)