### PR TITLE
Use O(1)-time search

### DIFF
--- a/lua/nvim-mapper.lua
+++ b/lua/nvim-mapper.lua
@@ -25,30 +25,20 @@ local function map(virtual, buffnr, mode, keys, cmd, options, category,
         buffer_only = buffer_only
     }
 
-    local new_records = vim.g.mapper_records
+    maybe_existing_record = vim.g.mapper_records[unique_identifier]
 
-    -- Check unique_identifier collisons
-    local already_defined = false
-    for i, _ in pairs(vim.g.mapper_records) do
-        local other_record = vim.g.mapper_records[i]
-        if (other_record.unique_identifier == unique_identifier) then
-            already_defined = true
-            -- If the exact same mapping exists, do not redefine
-            -- If the same unique_identifier exists but the rest is not the same, print error
-            if (other_record.mode == mode and other_record.keys == keys and
-                other_record.cmd == cmd and other_record.category == category and
-                other_record.description == description) then
-            else
-                print(
-                    "Mapper error : unique identifier " .. unique_identifier ..
-                        " cannot be used twice")
-            end
-
-        end
+    if maybe_existing_record == nil then
+        local new_records = vim.g.mapper_records
+        new_records[unique_identifier] = record
+        vim.g.mapper_records = new_records
+    elseif (maybe_existing_record.mode ~= mode or
+            maybe_existing_record.keys ~= keys or
+            maybe_existing_record.cmd ~= cmd or
+            maybe_existing_record.category ~= category or
+            maybe_existing_record.description ~= description) then
+        print("Mapper error : unique identifier " .. unique_identifier ..
+              " cannot be used twice")
     end
-
-    if not already_defined then table.insert(new_records, record) end
-    vim.g.mapper_records = new_records
 
     -- Set the mapping
     if not virtual then

--- a/lua/telescope/_extensions/mapper/previewers.lua
+++ b/lua/telescope/_extensions/mapper/previewers.lua
@@ -9,42 +9,40 @@ M.previewer = defaulter(function(_)
         title = "Mapping details",
         define_preview = function(self, entry, _)
             -- Find the mapping corresponding to the entry
-            for i, _ in pairs(vim.g.mapper_records) do
-                if (vim.g.mapper_records[i].unique_identifier == entry.unique_identifier) then
-                    -- Write the entry lines
-                    local lines = entry.lines
-                    vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+            if vim.g.mapper_records[entry.unique_identifier] == nil then return end
 
-                    -- Set wrap for the preview window
-                    vim.api.nvim_win_set_option(self.state.winid, "wrap", true)
+            -- Write the entry lines
+            local lines = entry.lines
+            vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
 
-                    -- Color
-                    local syntax_matches = {
-                        nvim_mapper_id = "^Id",
-                        nvim_mapper_cat = "^Category",
-                        nvim_mapper_mode = "^Mode",
-                        nvim_mapper_keys = "^Keys",
-                        nvim_mapper_cmd = "^Command",
-                        nvim_mapper_buf_only = "^Buffer only",
-                        nvim_mapper_description = "^Description",
-                        nvim_mapper_opts = "^Options",
-                        nvim_mapper_definition = "^Definition",
-                    }
+            -- Set wrap for the preview window
+            vim.api.nvim_win_set_option(self.state.winid, "wrap", true)
 
-                    -- Syntax colors
-                    for key, value in pairs(syntax_matches) do
-                        vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":syntax match " .. key .. " \"" .. value .. "\"") end)
-                        vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":hi link " .. key .. " Operator") end)
+            -- Color
+            local syntax_matches = {
+                nvim_mapper_id = "^Id",
+                nvim_mapper_cat = "^Category",
+                nvim_mapper_mode = "^Mode",
+                nvim_mapper_keys = "^Keys",
+                nvim_mapper_cmd = "^Command",
+                nvim_mapper_buf_only = "^Buffer only",
+                nvim_mapper_description = "^Description",
+                nvim_mapper_opts = "^Options",
+                nvim_mapper_definition = "^Definition",
+            }
 
-                        if (key == "nvim_mapper_keys" or key == "nvim_mapper_cmd" or key == "nvim_mapper_opts" or key == "nvim_mapper_id" or key == "nvim_mapper_definition") then
-                            vim.api.nvim_buf_call(self.state.bufnr, function()
-                                -- "\(^Definition: \+\)\@<=.*"
-                                vim.cmd(":syntax match MapperCode '\\(" .. value .. ": \\+\\)\\@<=.*'")
-                            end)
-                        end
-                        vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":hi link MapperCode Comment") end)
-                    end
+            -- Syntax colors
+            for key, value in pairs(syntax_matches) do
+                vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":syntax match " .. key .. " \"" .. value .. "\"") end)
+                vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":hi link " .. key .. " Operator") end)
+
+                if (key == "nvim_mapper_keys" or key == "nvim_mapper_cmd" or key == "nvim_mapper_opts" or key == "nvim_mapper_id" or key == "nvim_mapper_definition") then
+                    vim.api.nvim_buf_call(self.state.bufnr, function()
+                        -- "\(^Definition: \+\)\@<=.*"
+                        vim.cmd(":syntax match MapperCode '\\(" .. value .. ": \\+\\)\\@<=.*'")
+                    end)
                 end
+                vim.api.nvim_buf_call(self.state.bufnr, function() vim.cmd(":hi link MapperCode Comment") end)
             end
         end
     })

--- a/lua/telescope/_extensions/mapper/utils.lua
+++ b/lua/telescope/_extensions/mapper/utils.lua
@@ -17,12 +17,10 @@ M.get_mappers = function()
     end
 
     -- For each record, build a regex
-    for i, _ in pairs(records) do
-        local unique_identifier = records[i].unique_identifier
-
+    for unique_identifier, record in pairs(records) do
         local regex = '\\((.+,\\s*)+"' .. unique_identifier .. '"\\s*,.+\\)'
         table.insert(regex_table, regex)
-        records[i].regex = regex
+        record.regex = regex
     end
 
     -- Use rg to find all of these regex in one run
@@ -67,11 +65,17 @@ M.get_mappers = function()
     end
 
     -- Create the mapping scratch buffers text
-    for i, _ in pairs(records) do
-        records[i].lines = Record_buf_lines(records[i])
+    for _, record in pairs(records) do
+        record.lines = Record_buf_lines(record)
     end
 
-    return records
+    -- Telescope wants an indexed array
+    local indexed_records = {}
+    for _, record in pairs(records) do
+      table.insert(indexed_records, record)
+    end
+
+    return indexed_records
 end
 
 -- Make the text that is displayed in the preview


### PR DESCRIPTION
This commit significantly speeds up setup time. I have 84 custom
mappings, and after this commit vim's startup takes 100ms less
(~170ms -> 70ms).

Previous implementation used linear search to find identifier collisions
and defined mappings. This led to quadratic complexity and every new
mapping extended start up even more. The new implementation uses
identifiers as keys, which makes the search constant in time.

This commit also cleans up some idioms, e.g., changes
`for i, _ in table do f(table[i]) end` to just
`for _, v in table do f(v)` (the latter being slightly faster as we
avoid the table lookup).
