### PR TITLE
perf(mapper): avoid O(N^2) algorithm

### DIFF
--- a/lua/nvim-mapper.lua
+++ b/lua/nvim-mapper.lua
@@ -1,11 +1,10 @@
 -- nvim-mapper
 local M = {}
+M.mapper_records = {}
 
 -- Set a mapping
 local function map(virtual, buffnr, mode, keys, cmd, options, category,
                    unique_identifier, description)
-
-    if vim.g.mapper_records == nil then vim.g.mapper_records = {} end
 
     local buffer_only
     if buffnr == nil then
@@ -25,12 +24,10 @@ local function map(virtual, buffnr, mode, keys, cmd, options, category,
         buffer_only = buffer_only
     }
 
-    maybe_existing_record = vim.g.mapper_records[unique_identifier]
+    maybe_existing_record = M.mapper_records[unique_identifier]
 
     if maybe_existing_record == nil then
-        local new_records = vim.g.mapper_records
-        new_records[unique_identifier] = record
-        vim.g.mapper_records = new_records
+        M.mapper_records[unique_identifier] = record
     elseif (maybe_existing_record.mode ~= mode or
             maybe_existing_record.keys ~= keys or
             maybe_existing_record.cmd ~= cmd or

--- a/lua/telescope/_extensions/mapper/previewers.lua
+++ b/lua/telescope/_extensions/mapper/previewers.lua
@@ -1,6 +1,7 @@
 local previewers = require("telescope.previewers")
 local utils = require('telescope.utils')
 local defaulter = utils.make_default_callable
+local mapper = require('nvim-mapper')
 
 local M = {}
 
@@ -9,7 +10,7 @@ M.previewer = defaulter(function(_)
         title = "Mapping details",
         define_preview = function(self, entry, _)
             -- Find the mapping corresponding to the entry
-            if vim.g.mapper_records[entry.unique_identifier] == nil then return end
+            if mapper.mapper_records[entry.unique_identifier] == nil then return end
 
             -- Write the entry lines
             local lines = entry.lines

--- a/lua/telescope/_extensions/mapper/utils.lua
+++ b/lua/telescope/_extensions/mapper/utils.lua
@@ -9,7 +9,7 @@ M.get_mappers = function()
     local search_dir = vim.g.mapper_search_path
 
     -- Initialization
-    local records = vim.g.mapper_records
+    local records = require('nvim-mapper').mapper_records
     local regex_table = {}
 
     if records == nil then


### PR DESCRIPTION
Speed up neovim startup time by keeping the `mapper_records` data
structure entirely on the Lua side.
Copying it back and forth through the vimscript bridge (vim.g) would require
processing the entire table every time a new mapping is added, resulting
in an at least O(N^2) algorithm for N mappings.

This saves ~48ms of startup time (about half of my Neovim startup time).

Measurements done on a default doom-nvim install with NVIM v0.7.0 on
Fedora 36:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `HOME=compare_old nvim --headless -c "noautocmd qa!"` | 93.8 ± 1.7 | 91.2 | 99.8 | 2.06 ± 0.05 |
| `HOME=compare_new nvim --headless -c "noautocmd qa!"` | 45.4 ± 0.7 | 44.1 | 47.6 | 1.00 |

Measurement system:
```
CPU: 12-core AMD Ryzen 9 3900X (-MT MCP-) speed/min/max: 3776/2200/4672 MHz
Kernel: 5.17.11-300.fc36.x86_64 x86_64 Up: 3h 1m
Mem: 5971.2/64280.0 MiB (9.3%) Storage: 24.99 TiB (0.5% used) Procs: 499
Shell: Zsh inxi: 3.3.16
```

I've also benchmarked the pure Lua and vim.g.mapper_records methods in more detail: https://gist.github.com/edwintorok/01890b48caa300063be00ab2ead179f9

Here is a plot, the vim.g method becomes slower and slower the more keybindings are added (shown on a log scale here), e.g. at 200 keybindings we are already at ~76ms, whereas the pure Lua method of storing state is at ~0.2ms. With more keybindings this would become even slower (it can reach ~0.5s with enough keybindings):
![visualization](https://user-images.githubusercontent.com/721894/172021274-aaaf6b24-ff7b-4f21-892f-c3999c5f5eb1.svg)

(FWIW doom-nvim has ~145 keybindings by default, so having a lot of keybindings is not that far fetched)

